### PR TITLE
Improve noscript UX

### DIFF
--- a/content/downloads/index.md
+++ b/content/downloads/index.md
@@ -20,10 +20,12 @@ So I am showing you all the options.
 
 <p id='others'>
 Show downloads for 
-<span class="show_links" id='os_linux'>GNU/Linux</span>&nbsp;| 
-<span class="show_links" id='os_mac'>OS&nbsp;X</span>&nbsp;| 
-<span class="show_links" id='os_win'>Microsoft&nbsp;Windows</span>&nbsp;| 
-<span class="show_links" id='os_all'>All</span>
+http://www.gimp.org/downloads/
+
+<span class="show_links" id='os_linux'><a href="#gimp-for-unix-like-systems">GNU/Linux</a></span>&nbsp;| 
+<span class="show_links" id='os_mac'><a href="#gimp-for-mac-os-x">OS&nbsp;X</a></span>&nbsp;| 
+<span class="show_links" id='os_win'><a href="#gimp-for-windows">Microsoft&nbsp;Windows</a></span>&nbsp;| 
+<span class="show_links" id='os_all'><a href="#gimp-for-unix-like-systems">All</a></span>
 </p>
 
 </div>


### PR DESCRIPTION
As a noscript user
When I try to download Gimp
Then I get a helpful noscript message
But the links in that message don't work
![gimp-fix](https://cloud.githubusercontent.com/assets/764725/16099899/d2bde79e-3328-11e6-8fcd-537e32f52bcf.PNG)

This PR makes the "Show downloads for Microsoft Windows" item actually show downloads for Windows when clicked in a noscript browser.

It also appears to break the with-javascript behavior of showing only one platform at a time, at least if one of the links is clicked. imo not a big loss
